### PR TITLE
Connects to #54. When no bronhouder geometry was returned, the wrong exception...

### DIFF
--- a/managerDB/src/main/java/nl/ipo/cds/dao/impl/ManagerDaoImpl.java
+++ b/managerDB/src/main/java/nl/ipo/cds/dao/impl/ManagerDaoImpl.java
@@ -922,8 +922,10 @@ public class ManagerDaoImpl implements ManagerDao {
 			value = (byte[])query.getSingleResult ();
 		} catch (NoResultException e) {
 			return null;
+		} catch (EmptyResultDataAccessException e) {
+			return null;
 		}
-		
+
 		try {
 			return WKBReader.read (value, null);
 		} catch (ParseException e) {


### PR DESCRIPTION
... was catched.