### PR TITLE
  Fix handling of dataset UUID changes

### DIFF
--- a/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
+++ b/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
@@ -35,6 +35,7 @@ import nl.ipo.cds.domain.BronhouderThema;
 import nl.ipo.cds.domain.Dataset;
 import nl.ipo.cds.domain.DatasetType;
 import nl.ipo.cds.domain.FeatureType;
+import nl.ipo.cds.domain.ImportJob;
 import nl.ipo.cds.domain.RemoveJob;
 import nl.ipo.cds.domain.Thema;
 import nl.ipo.cds.domain.TransformJob;

--- a/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
+++ b/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
@@ -267,6 +267,7 @@ public class DatasetController{
 	 * The proper working depends on the lists having the order in which items appear on the html form.
 	 * @return view url
 	 */
+	@Transactional
 	@RequestMapping(value ="/ba/datasetconfig/{bronhouderId}", method = RequestMethod.POST)
 	public String updateDataset(@PathVariable Long bronhouderId, 
 			@RequestParam(value="thema", required=true) String themaName,  
@@ -281,7 +282,12 @@ public class DatasetController{
 				if (dataset.getDatasetType().getNaam().equals(bronhouderDataset.getType())) {
 					dataset.setNaam(bronhouderDataset.getNaam());
 					dataset.setActief(bronhouderDataset.isActief());
-					dataset.setUuid(bronhouderDataset.getUuid());
+					final String oldUuid = dataset.getUuid();
+					final String newUuid = bronhouderDataset.getUuid();
+					if (!oldUuid.equals(newUuid)) {
+						dataset.setUuid(newUuid);
+						removeAndReimportDataAfterUuidChange(dataset, oldUuid, newUuid);
+					}
 					this.managerDao.update(dataset);
 				}
 			}
@@ -290,6 +296,27 @@ public class DatasetController{
         // Redirect after POST pattern
 		redirectAttributes.addAttribute ("thema", themaName);
         return "redirect:/ba/datasetconfig/" + bronhouderId;
+	}
+
+	private void removeAndReimportDataAfterUuidChange(final Dataset dataset, final String oldUuid, final String newUuid ) {
+
+		final RemoveJob deleteJob = new RemoveJob ();
+		deleteJob.setBronhouder(dataset.getBronhouder());
+		deleteJob.setDatasetType(dataset.getDatasetType());
+		deleteJob.setUuid(oldUuid);
+		jobCreator.putJob (deleteJob);
+
+		final ImportJob job = new ImportJob ();
+		job.setBronhouder(dataset.getBronhouder());
+		job.setDatasetType(dataset.getDatasetType());
+		job.setUuid(newUuid);
+		job.setForceExecution(true);
+		jobCreator.putJob (job);
+
+		if(this.managerDao.getLastTransformJob(Job.Status.CREATED) == null){
+			final TransformJob transformJob = new TransformJob ();
+			managerDao.create (transformJob);
+		}
 	}
 	
 	@Transactional

--- a/domain/src/main/java/nl/ipo/cds/domain/RemoveJob.java
+++ b/domain/src/main/java/nl/ipo/cds/domain/RemoveJob.java
@@ -7,7 +7,7 @@ import javax.persistence.Entity;
 @DiscriminatorValue ("REMOVE")
 public class RemoveJob extends EtlJob {
 
-	private final static int PRIORITY = 200;
+	private final static int PRIORITY = 250;
 	
 	public RemoveJob () {
 		super (PRIORITY);


### PR DESCRIPTION
Before this patch, changing the UUID would result in duplicate features in the bron and inspire schemas.

Now, changing of UUID via UI triggers the following actions:

* Change UUID of dataset
* Schedule removing of old features
* Schedule importing of new dataset
* Schedule transformation